### PR TITLE
fix: wait for tx committed before read its data

### DIFF
--- a/test/type/types_test.js
+++ b/test/type/types_test.js
@@ -36,6 +36,7 @@ describe("type  max min data test",function (){
             })
             let tx = await contract.typeUint8(255,[255,255,255],[255,255,255]);
             console.log("typeUint8 hash :",tx.hash);
+            await tx.wait();
             let reusltGetUint8 =await contract.getUint8();
             //expected log
             expect(reusltGetUint8.toString()).to.be.equal('255,255,255,255,255,255,255')
@@ -74,8 +75,9 @@ describe("type  max min data test",function (){
         })
 
         it("typeU256 max: ", async () => {
-            await contract.setUint256(65535);
-            let x =await contract.getUint256();
+            let tx = await contract.setUint256(65535);
+            await tx.wait();
+            let x = await contract.getUint256();
             expect(x).to.be.equal(65535)
         })
 
@@ -292,7 +294,8 @@ describe("type  max min data test",function (){
 
         it("typeString:", async () => {
 
-            await contract.changName();
+            let tx = await contract.changName();
+            await tx.wait();
             console.log("The new string  is :", await contract.getName());
             expect(await contract.getName()).to.equal("Zrptotest")
 


### PR DESCRIPTION
### Description

Some tests have read data from contracts, before the transaction which changes the data is committed.

These bugs are only happened after axonweb3/axon#1526 and only in CI because:
- After axonweb3/axon#1526, the `eth_getTransactionByHash` has data when transactions just in mempool, so the call of functions will return earlier.
- The CI environment is low performance, but our local development is good enough.

### Tests

Before this PR:
- [Failed test #7](https://github.com/axonweb3/axon/actions/runs/6794716156/job/18471564696#step:13:37098)
- [Failed test #8](https://github.com/axonweb3/axon/actions/runs/6794716156/job/18471564696#step:13:37111)
- [Failed test #10](https://github.com/axonweb3/axon/actions/runs/6794716156/job/18471564696#step:13:37129)

After this PR:
- [The above tests are fixed.](https://github.com/axonweb3/axon/actions/runs/6795798796/job/18474574839#step:13:38087)
  _p.s. That CI check still has failed tests, they will be fixed in other PRs later; I haven't figured out them now._