### PR TITLE
fix: wait for txs committed before read nonce to build next tx

### DIFF
--- a/.github/workflows/ci_axon.yml
+++ b/.github/workflows/ci_axon.yml
@@ -17,15 +17,13 @@ jobs:
 
       - name: Checkout Axon Tests
         uses: actions/checkout@v4
-        # TODO Fix CI at first, then fix tests later.
-        with:
-          ref: 0e2e379ac17175c301115127ea679f1d0085ddc3
 
       - name: Checkout Axon
         uses: actions/checkout@v4
         with:
           repository: axonweb3/axon
-          ref: 2a88c0ce1e61c68cd114ca36ef4f05cb7f6a07e8
+          # axonweb3/axon#1526
+          ref: bc7336aad8d23a1d2b6ff4399d01848ba828e758
           path: axon
 
       - name: Cache of Cargo

--- a/test/failedTx/rpc_failed_tx.js
+++ b/test/failedTx/rpc_failed_tx.js
@@ -33,9 +33,9 @@ describe("Failed commit tx", function () {
     let failedContract080;
 
     before(async function () {
-        console.log('070')
+        console.log('prepare 1st failed tx')
         failedContract070 = await prepareFailedTxContract("contracts/failedTx/failedTxContract0.7.0.sol:FailedTxContract")
-        console.log('080')
+        console.log('prepare 2nd failed tx')
         failedContract080 = await prepareFailedTxContract("contracts/failedTx/failedTxContract.0.8.4.sol:FailedTxContract")
 
     });
@@ -207,18 +207,21 @@ async function checkResponseOfFailedTx(txHash, isLow080Panic) {
 
 async function prepareFailedTxContract(solFailedTxContractPath) {
     let contractInfo = await ethers.getContractFactory(solFailedTxContractPath);
-    let contractInfo1 = await ethers.getContractFactory(solFailedTxContractPath);
-    let contractInfo2 = await ethers.getContractFactory(solFailedTxContractPath);
-
-    let contract1 = await contractInfo1.deploy()
-    let contract = await contractInfo.deploy()
-    let contract2 = await contractInfo2.deploy()
-    await contract2.deployed();
+    let contract = await contractInfo.deploy();
     await contract.deployed();
+
+    let contractInfo1 = await ethers.getContractFactory(solFailedTxContractPath);
+    let contract1 = await contractInfo1.deploy();
     await contract1.deployed();
+
+    let contractInfo2 = await ethers.getContractFactory(solFailedTxContractPath);
+    let contract2 = await contractInfo2.deploy();
+    await contract2.deployed();
+
     //deploy ckb proxy address
     //invoke prepare method
-    await contract.prepare(contract1.address, contract2.address, {"value": "0x123450"})
+    let tx = await contract.prepare(contract1.address, contract2.address, {"value": "0x123450"});
+    await tx.wait();
     return contract;
 }
 

--- a/test/godwoken/failedTx.js
+++ b/test/godwoken/failedTx.js
@@ -1,13 +1,12 @@
 const {expect} = require("chai");
 const {ethers, waffle} = require("hardhat");
+const {getTxReceipt} = require("../utils/rpc");
 
 let contract;
 
 describe('Revertable transaction', function () {
     this.timeout(600000)
 
-
-    let provider = waffle.provider;
 
     beforeEach(async function () {
         const factory = await ethers.getContractFactory("RevertHandling");
@@ -44,10 +43,11 @@ describe('Revertable transaction', function () {
         it('revert transferred value', async () => {
             // set transaction params
             const value = 10;
+            const msg = 'Hello';
 
             // set message
-            const tx = await contract.setMsg(0, 'Hello', {value: value, gasLimit: 30000});
-            const receipt = await provider.getTransactionReceipt(tx.hash);
+            const tx = await contract.setMsg(0, msg, {value: value, gasLimit: 30000});
+            const receipt = await getTxReceipt(ethers.provider, tx.hash, 100)
 
             // check receipt
             expect(receipt.status).to.be.equal(0, 'transaction should be failed');
@@ -59,7 +59,7 @@ describe('Revertable transaction', function () {
 
             // check nonce
             const accounts = await ethers.getSigners();
-            const nonce = await provider.getTransactionCount(accounts[0].address);
+            const nonce = await ethers.provider.getTransactionCount(accounts[0].address);
             expect(nonce).to.be.greaterThan(tx.nonce, 'current nonce should be greater than last time');
         });
     });

--- a/test/opcodes/opcodeTxWithMsg.js
+++ b/test/opcodes/opcodeTxWithMsg.js
@@ -14,9 +14,9 @@ describe("opcodeTxWithMsg.js opcode -tx msg ", function () {
     before(async function () {
         const blockInfoContract = await ethers.getContractFactory("opcodeTxWithMsg");
         contractWithValue = await blockInfoContract.deploy({value: 10n, gasPrice: 91111n});
+        await contractWithValue.deployed();
         const blockInfoContract2 = await ethers.getContractFactory("opcodeTxWithMsg");
         contract2NoValue = await blockInfoContract2.deploy({gasPrice: 91112n});
-        await contractWithValue.deployed();
         await contract2NoValue.deployed();
     });
 
@@ -86,12 +86,11 @@ describe("opcodeTxWithMsg.js opcode -tx msg ", function () {
         before(async function () {
             //todo check  no  mod gasLimit will pass
             txWithValue = await contractWithValue.updateMsgAndTxData({gasPrice: 91234, gasLimit: 6000000});
-            txWithNoValue = await contract2NoValue.updateMsgAndTxData({gasPrice: 90000, gasLimit: 6000000});
-
             receiptWithValue = await txWithValue.wait();
             msgDatWithValue = await contractWithValue.msgData();
             txDataWithValue = await contractWithValue.txData();
 
+            txWithNoValue = await contract2NoValue.updateMsgAndTxData({gasPrice: 90000, gasLimit: 6000000});
             receiptNoValue = await txWithNoValue.wait();
             msgDatNoValue = await contract2NoValue.msgData();
             txDataNoValue = await contract2NoValue.txData();

--- a/test/other/eventTestContract.test.js
+++ b/test/other/eventTestContract.test.js
@@ -14,7 +14,7 @@ describe("eventTestContract", function () {
         console.log("contractAddress:", contract.address);
     });
 
-    it("emit 10000 log ,should return 100000 log msg ", async () => {
+    it("emit 10000 log ,should return 10000 log msg ", async () => {
         let tx = await contract.testLog(10000, {gasLimit: 25000000});
         let response = await tx.wait()
         expect(response.logs.length).to.be.equal(10000)

--- a/test/rpc/eth_sendRawTransaction.test.js
+++ b/test/rpc/eth_sendRawTransaction.test.js
@@ -295,11 +295,12 @@ describe("eth_sendRawTransaction ", function () {
                 let currentAddress = await ethers.provider.getSigner().getAddress();
                 let sendBeforeNonces = await getTxCount(currentAddress);
                 let penddingNonce = await ethers.provider.getTransactionCount(ethers.provider.getSigner().getAddress(), "pending")
-                await ethers.provider.getSigner().sendTransaction({
+                let tx = await ethers.provider.getSigner().sendTransaction({
                     "to": null,
                     "nonce": penddingNonce,
                     "data": logContract.bytecode,
                 })
+                await tx.wait();
                 let sendReturnHashNonces = await getTxCount(currentAddress);
                 expect(sendBeforeNonces[0]).to.be.equal(sendBeforeNonces[1])
                 expect(sendReturnHashNonces[0]).to.be.equal(sendReturnHashNonces[1])


### PR DESCRIPTION
I don't sure whether it's a bug of Axon JSON-RPC or not.

If two transactions with a same sender are sent one by one, then they have a chance to use a same nonce.

So, this PR updates tests to make sure each transaction is constructed after the previous transaction mined.

The tests after this PR should be passed with axonweb3/axon#1526.